### PR TITLE
Fixes clang compiler bug in argument deduction

### DIFF
--- a/load.hpp
+++ b/load.hpp
@@ -12,46 +12,46 @@ using namespace util;
 
 namespace util { namespace serialize { namespace binary {
 
- // template <typename T, EnableIfString                 <T>...> T load(std::ifstream&, T&);
-    template <typename T, EnableIfFundamental            <T>...> T load(std::ifstream&);
-    template <typename T, EnableIfAssociativeContainer   <T>...> T load(std::ifstream&);
-    template <typename T, EnableIfNonAssociativeContainer<T>...> T load(std::ifstream&);
-    template <typename T, EnableIfArray                  <T>...> T load(std::ifstream&);
+ // template <typename T, EnableIfString                 <T> = detail::dummy> T load(std::ifstream&, T&);
+    template <typename T, EnableIfFundamental            <T> = detail::dummy> T load(std::ifstream&);
+    template <typename T, EnableIfAssociativeContainer   <T> = detail::dummy> T load(std::ifstream&);
+    template <typename T, EnableIfNonAssociativeContainer<T> = detail::dummy> T load(std::ifstream&);
+    template <typename T, EnableIfArray                  <T> = detail::dummy> T load(std::ifstream&);
     template<class K, class V>                      std::pair<K,V> load(std::ifstream&);
 
- // template <typename T, EnableIfString                 <T>...> T load(std::ifstream&, T&);
-    template <typename T, EnableIfFundamental            <T>...> T load(std::ifstream&, T&);
-    template <typename T, EnableIfAssociativeContainer   <T>...> T load(std::ifstream&, T&);
-    template <typename T, EnableIfNonAssociativeContainer<T>...> T load(std::ifstream&, T&);
-    template <typename T, EnableIfArray                  <T>...> T load(std::ifstream&, T&);
+ // template <typename T, EnableIfString                 <T> = detail::dummy> T load(std::ifstream&, T&);
+    template <typename T, EnableIfFundamental            <T> = detail::dummy> T load(std::ifstream&, T&);
+    template <typename T, EnableIfAssociativeContainer   <T> = detail::dummy> T load(std::ifstream&, T&);
+    template <typename T, EnableIfNonAssociativeContainer<T> = detail::dummy> T load(std::ifstream&, T&);
+    template <typename T, EnableIfArray                  <T> = detail::dummy> T load(std::ifstream&, T&);
     template<class K, class V>                      std::pair<K,V> load(std::ifstream&, std::pair<K,V>&);
 
 
-    template <typename T, EnableIfFundamental <T>...>
+    template <typename T, EnableIfFundamental <T>>
     T load(std::ifstream& in) {
         T t;
         return load(in, t);
     }
-    
-    template <typename T, EnableIfAssociativeContainer <T>...>
+
+    template <typename T, EnableIfAssociativeContainer <T>>
     T load(std::ifstream& in) {
         T t;
         return load(in, t);
     }
-    
-    template <typename T, EnableIfNonAssociativeContainer<T>...>
+
+    template <typename T, EnableIfNonAssociativeContainer<T>>
     T load(std::ifstream& in) {
         T t;
         return load(in, t);
     }
-    
-    template <typename T, EnableIfArray <T>...>
+
+    template <typename T, EnableIfArray <T>>
     T load(std::ifstream& in) {
         T t;
         return load(in, t);
     }
-    
-    // template <typename T, EnableIfString <T>...>
+
+    // template <typename T, EnableIfString <T>>
     // T load(std::ifstream&, T& in) {
     //     T t;
     //     return load(in, t);
@@ -67,7 +67,7 @@ namespace util { namespace serialize { namespace binary {
     /*                  L  O  A  D                                               */
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-    template <typename T, EnableIfFundamental<T>...>
+    template <typename T, EnableIfFundamental<T>>
     T
     load(std::ifstream & is, T & t) {
         is.read(reinterpret_cast<char*>(&t), /*static_cast<(std::streamsize)*/sizeof(t) );
@@ -75,7 +75,7 @@ namespace util { namespace serialize { namespace binary {
     }
 
 
-    template <typename T, EnableIfAssociativeContainer<T>...>
+    template <typename T, EnableIfAssociativeContainer<T>>
     T
     load(std::ifstream & is, T & t) {
         unsigned size = 0;
@@ -96,7 +96,7 @@ namespace util { namespace serialize { namespace binary {
     }
 
 
-    template <typename T, EnableIfNonAssociativeContainer<T>...>
+    template <typename T, EnableIfNonAssociativeContainer<T>>
     T
     load(std::ifstream & is, T & t) {
         unsigned size = 0;
@@ -112,7 +112,7 @@ namespace util { namespace serialize { namespace binary {
         return t;
     }
 
-    template <typename T, EnableIfArray<T>...>
+    template <typename T, EnableIfArray<T>>
     T
     load(std::ifstream & is, T & t) {
         is.read(reinterpret_cast<char*>(&t), /*static_cast<(std::streamsize)*/sizeof(t) );
@@ -120,7 +120,7 @@ namespace util { namespace serialize { namespace binary {
     }
 
 
-    // template <typename T, EnableIfString<T>...>
+    // template <typename T, EnableIfString<T>>
     // T
     // load(std::ifstream & is, T & t) {
     //     size_t  size = 0;

--- a/save.hpp
+++ b/save.hpp
@@ -12,10 +12,10 @@
 namespace util { namespace serialize { namespace binary {
 
     // forward declarations
-    template <typename T, EnableIfFundamental<T>...> T save(std::ofstream&, T);
-    template <typename T, EnableIfContainer  <T>...> T save(std::ofstream&, T);
-    template <typename T, EnableIfArray      <T>...> T save(std::ofstream&, T);
-    // template <typename T, EnableIfString     <T>...> T save(std::ofstream&, T);
+    template <typename T, EnableIfFundamental<T> = detail::dummy> T save(std::ofstream&, T);
+    template <typename T, EnableIfContainer  <T> = detail::dummy> T save(std::ofstream&, T);
+    template <typename T, EnableIfArray      <T> = detail::dummy> T save(std::ofstream&, T);
+    // template <typename T, EnableIfString     <T> = detail::dummy> T save(std::ofstream&, T);
     template<class K, class V>          std::pair<K,V> save(std::ofstream&, std::pair<K,V>);
 
 
@@ -24,14 +24,14 @@ namespace util { namespace serialize { namespace binary {
     /*                  S  A  V  E                                               */
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-    template <typename T, EnableIfFundamental<T>...>
+    template <typename T, EnableIfFundamental<T>>
     T
     save(std::ofstream & os, T t) {
         os.write(reinterpret_cast<const char*>(&t), sizeof(t));
         return t;
     }
 
-    template <typename T, EnableIfContainer<T>...>
+    template <typename T, EnableIfContainer<T>>
     T
     save(std::ofstream & os, T t) {
         unsigned size = t.size();
@@ -43,7 +43,7 @@ namespace util { namespace serialize { namespace binary {
         return t;
     }
 
-    template <typename T, EnableIfArray<T>...>
+    template <typename T, EnableIfArray<T>>
     T
     save(std::ofstream & os, T t) {
         unsigned size = t.size();
@@ -52,7 +52,7 @@ namespace util { namespace serialize { namespace binary {
         return t;
     }
 
-    // template <typename T, EnableIfString<T>...>
+    // template <typename T, EnableIfString<T>>
     // T
     // save(std::ofstream & os, T t) {
     //     size_t       size = t.size() + 1;

--- a/type_traits/extended/is_container.hpp
+++ b/type_traits/extended/is_container.hpp
@@ -89,9 +89,10 @@ using RemoveCv = Invoke<remove_cv<T>>;
 template <typename T>
 using Unqualified = RemoveCv<RemoveReference<T>>;
 
-
-
-namespace detail { enum class enabler {}; }
+namespace detail {
+enum class enabler { DUMMY };
+constexpr const enabler dummy = enabler::DUMMY;
+}
 
 template <typename... Condition>
 using EnableIf = typename std::enable_if<all<Condition...>::value, detail::enabler>::type;


### PR DESCRIPTION
This PR fixes a `clang` compiler bug in argument deduction:

``` bash
....
test_binary.cpp:51:17: error: call to 'load' is ambiguous
    auto t_in = usb::load<T>(is);
                ^~~~~~~~~~~~
./load.hpp:31:7: note: candidate function [with T = std::__cxx11::basic_string<char>, $1 = <>]
    T load(std::ifstream& in) {
      ^
./load.hpp:37:7: note: candidate function [with T = std::__cxx11::basic_string<char>, $1 = <>]
    T load(std::ifstream& in) {
      ^
./load.hpp:43:7: note: candidate function [with T = std::__cxx11::basic_string<char>, $1 = <>]
    T load(std::ifstream& in) {
      ^
./load.hpp:49:7: note: candidate function [with T = std::__cxx11::basic_string<char>, $1 = <>]
    T load(std::ifstream& in) {
      ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```

See [1] for further information. With this patch compilation on `clang` with the latest version _3.8_ works without problems, tested on _Arch Linux_:

``` bash
$ clang++ --version
clang version 3.8.1 (tags/RELEASE_381/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
$ rake
clang++ -std=c++11 -Wall -Wextra test_binary.cpp -o test_binary.test
./test_binary.test
All tests run successful.
```

[1] https://llvm.org/bugs/show_bug.cgi?id=11723
